### PR TITLE
add fallback option to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,13 @@
       "deno": "./esm/deno/index.js",
       "node": "./esm/node/index.js",
       "require": "./cjs/index.cjs"
-    }
+    },
+    "import": "./esm/node/index.mjs",
+    "require": "./cjs/index.cjs"
+    "default": "./esm/node/index.js"
   },
+  "main: "./cjs/index.cjs",
+  "module": "./esm/node/index.mjs",
   "workspaces": [
     "demo",
     "test"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "require": "./cjs/index.cjs"
     "default": "./esm/node/index.js"
   },
-  "main: "./cjs/index.cjs",
+  "main": "./cjs/index.cjs",
   "module": "./esm/node/index.mjs",
   "workspaces": [
     "demo",


### PR DESCRIPTION
I found that https://bundlephobia.com/package/u8-mqtt refuses to show bundle size. According to https://nodejs.org/api/packages.html#dual-commonjses-module-packages there a few lines to cover fallback should be added.